### PR TITLE
Import correct slackbot_settings.py during tests

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
 
 import sys
+import os
 import logging
 import logging.config
-from slackbot import settings
-from slackbot.bot import Bot
 
 
 def main():
+    if os.environ.get('SLACKBOT_TEST'):
+        sys.path.insert(0, os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), 'tests/functional'))
+
+    from slackbot import settings
+    from slackbot.bot import Bot
+
     kw = {
         'format': '[%(asctime)s] %(message)s',
         'datefmt': '%m/%d/%Y %H:%M:%S',

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -33,7 +33,6 @@ def _start_bot_process():
     env = dict(os.environ)
     env['SLACKBOT_API_TOKEN'] = testbot_apitoken
     env['SLACKBOT_TEST'] = 'true'
-    env['PYTHONPATH'] = ':'.join([dirname(abspath(__file__)), env.get('PYTHONPATH', '')])
     return subprocess.Popen(args, env=env)
 
 @pytest.yield_fixture(scope='module') # pylint: disable=E1101


### PR DESCRIPTION
If a slackbot_settings.py is in the same dir as run.py, it
was imported during tests rather than the one in the functional
dir. This change looks for the test environment variable and updates
sys.path to ensure that the test settings file is imported first
rather than any locally defined settings file.